### PR TITLE
Support all parameters to users_games endpoint

### DIFF
--- a/lib/lichess/exceptions.rb
+++ b/lib/lichess/exceptions.rb
@@ -2,6 +2,7 @@ module Lichess
   module Exception
     class UserNotFound < StandardError; end
     class TooManyGames < StandardError; end
+    class InvalidParameter < StandardError; end
   end
 end
 

--- a/lib/lichess/games_gateway.rb
+++ b/lib/lichess/games_gateway.rb
@@ -6,6 +6,10 @@ module Lichess
 
     MAX_GAMES = 30
 
+    VALID_PARAMS = {
+      users_games: %w{perf perfType since until max vs rated color analysed ongoing movies pgnInJson tags clocks evals opening players ongoing, num_games}.map(&:to_sym)
+    }
+
     def initialize(client)
       @client = client
     end
@@ -21,12 +25,16 @@ module Lichess
       JSON.parse(result.body)
     end
 
+
     def users_games(user_id, options = {}, &blk)
       num_games = options[:num_games] || 10
 
       if num_games > MAX_GAMES
         raise Exception::TooManyGames.new("Cannot request more than 30 games")
       end
+
+      invalid_params = options.keys.reject { |k| VALID_PARAMS[:users_games].include? k }
+      raise Exception::InvalidParameter.new("#{invalid_params.join(",")} parameters were supplied, but are invalid") if invalid_params.any?
 
       path = "/api/games/user/#{user_id}?max=#{num_games}"
 

--- a/lib/lichess/games_gateway.rb
+++ b/lib/lichess/games_gateway.rb
@@ -29,9 +29,13 @@ module Lichess
       end
 
       path = "/api/games/user/#{user_id}?max=#{num_games}"
-      path << "&ongoing=#{options[:ongoing]}" if options[:ongoing]
+
+      # kept to keep backward compat
       path << "&perfType=#{options[:perf]}" if options[:perf]
-      path << "&vs=#{options[:vs]}" if options[:vs]
+
+      options.each do |key, value|
+        path << "&#{key}=#{value}"
+      end
 
       result = @client.get(path, http_headers: ndjson_headers)
       stringio = StringIO.new(result.body)

--- a/spec/games_gateway_spec.rb
+++ b/spec/games_gateway_spec.rb
@@ -103,6 +103,12 @@ RSpec.describe Lichess::GamesGateway do
         games_gateway.users_games("farnswurth", num_games: Lichess::GamesGateway::MAX_GAMES + 1)
       end.to raise_error(Lichess::Exception::TooManyGames)
     end
+
+    it "rejects invalid parameters" do
+      expect do
+        games_gateway.users_games("jfredett", eris: "kallisti")
+      end.to raise_error(Lichess::Exception::InvalidParameter)
+    end
   end
 
   describe "#ongoing_games" do


### PR DESCRIPTION
Hello @omgrr!

 I'm working on a project that requires me to be able to specify some presently unsupported parameters for the users_games endpoint, so I went through and added some code to handle them and check for invalid parameters. I kept the checking separate as it would mean you'd need to maintain it if lichess ever adds more params. I added an explicit test around invalid params, but didn't add specific ones for each param as it seemed redundant.